### PR TITLE
added port to live reload html

### DIFF
--- a/const.go
+++ b/const.go
@@ -9,7 +9,7 @@ const (
 	<script type="text/javascript">
 	!function (w, c) {
 		try{
-			(new WebSocket('ws://' + w.location.host + '/', 'livedev')).onclose=function(){w.location.reload()}
+			(new WebSocket('ws://' + w.location.host + ':%d/', 'livedev')).onclose=function(){w.location.reload()}
 		}catch(ex){c.log('Livedev: ', err)}
 	}(window, window.console||{log:function(){}})
     </script>

--- a/const.go
+++ b/const.go
@@ -9,7 +9,7 @@ const (
 	<script type="text/javascript">
 	!function (w, c) {
 		try{
-			(new WebSocket('ws://' + w.location.host + ':%d/', 'livedev')).onclose=function(){w.location.reload()}
+			(new WebSocket('ws://' + w.location.hostname + ':%d/', 'livedev')).onclose=function(){w.location.reload()}
 		}catch(ex){c.log('Livedev: ', err)}
 	}(window, window.console||{log:function(){}})
     </script>

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 			log.Fatalf(`Fatal error: Duplicate server name "%s"`, s.Host)
 		}
 
-		srv, err := newServer(context, s, w)
+		srv, err := newServer(context, s, conf.Port, w)
 
 		if err != nil {
 			log.Fatalf(`Fatal error: Server binary not found "%s" : %v`, s.Host, err)

--- a/proxy.go
+++ b/proxy.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"html/template"
 	"net"
 	"net/http"
 	"path/filepath"
@@ -185,9 +186,9 @@ func (p *proxy) handleError(w http.ResponseWriter, err ServerError, code int) {
 	templateData["Name"] = err.Name
 	templateData["Message"] = err.Message
 	templateData["Data"] = err.Data
-	templateData["LiveReloadHTML"] = fmt.Sprintf(liveReloadHTML, p.port)
+	templateData["LiveReloadHTML"] = template.HTML(fmt.Sprintf(liveReloadHTML, p.port))
 
-	errTemplate.Execute(w, err)
+	errTemplate.Execute(w, templateData)
 }
 
 func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/proxy.go
+++ b/proxy.go
@@ -179,6 +179,14 @@ func (p *proxy) handleError(w http.ResponseWriter, err ServerError, code int) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(code)
+
+	// create template context
+	templateData := make(map[string]interface{})
+	templateData["Name"] = err.Name
+	templateData["Message"] = err.Message
+	templateData["Data"] = err.Data
+	templateData["LiveReloadHTML"] = fmt.Sprintf(liveReloadHTML, p.port)
+
 	errTemplate.Execute(w, err)
 }
 

--- a/server.go
+++ b/server.go
@@ -183,6 +183,7 @@ type Server struct {
 	cmd          *exec.Cmd
 	processState uint32
 	conf         serverConfig
+	proxyPort    int
 }
 
 func (srv *Server) setProcessState(state processState) {
@@ -266,10 +267,11 @@ func (srv *Server) runOnce() {
 	})
 }
 
-func newServer(context build.Context, conf serverConfig, w *watcher.Watcher) (*Server, error) {
+func newServer(context build.Context, conf serverConfig, proxyPort int, w *watcher.Watcher) (*Server, error) {
 	var err error
 	srv := new(Server)
 	srv.conf = conf
+	srv.proxyPort = proxyPort
 
 	srv.resources, err = newResource(conf.Resources.Paths, conf.Resources.Ignore)
 
@@ -811,7 +813,7 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 
 	if strings.HasPrefix(response.Header.Get("Content-Type"), "text/html") {
 		var contentLen int
-		body, contentLen, err = appendLiveScript(body, response.Header.Get("Content-Encoding"), srv.port)
+		body, contentLen, err = appendLiveScript(body, response.Header.Get("Content-Encoding"), srv.proxyPort)
 
 		if err != nil {
 			return err

--- a/server.go
+++ b/server.go
@@ -811,7 +811,7 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 
 	if strings.HasPrefix(response.Header.Get("Content-Type"), "text/html") {
 		var contentLen int
-		body, contentLen, err = appendLiveScript(body, response.Header.Get("Content-Encoding"))
+		body, contentLen, err = appendLiveScript(body, response.Header.Get("Content-Encoding"), srv.port)
 
 		if err != nil {
 			return err
@@ -828,7 +828,7 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func appendLiveScript(body io.Reader, encoding string) (r io.Reader, i int, err error) {
+func appendLiveScript(body io.Reader, encoding string, port int) (r io.Reader, i int, err error) {
 	if encoding == "gzip" {
 		r, err = gzip.NewReader(body)
 
@@ -840,7 +840,7 @@ func appendLiveScript(body io.Reader, encoding string) (r io.Reader, i int, err 
 	data, err := ioutil.ReadAll(body)
 
 	if err == nil {
-		data, err = appendHTML(data, []byte(liveReloadHTML))
+		data, err = appendHTML(data, []byte(fmt.Sprintf(liveReloadHTML, port)))
 	}
 
 	if err != nil {

--- a/templates.go
+++ b/templates.go
@@ -1,11 +1,8 @@
 package main
 
-import (
-	"fmt"
-	"html/template"
-)
+import "html/template"
 
-var errTemplate = template.Must(template.New("error").Parse(fmt.Sprintf(`
+var errTemplate = template.Must(template.New("error").Parse(`
 <!DOCTYPE html>
 <html lang="en-US" dir="ltr">
 	<head>
@@ -38,9 +35,9 @@ var errTemplate = template.Must(template.New("error").Parse(fmt.Sprintf(`
 			{{end}}
 		{{end}}
 		</code>
-		%s
+		{{ .LiveReloadHTML}}
 	</body>
-</html>`, liveReloadHTML)))
+</html>`))
 
 var codeviewerTemplate = template.Must(template.New("codeviewer").Parse(`
 <!DOCTYPE html>


### PR DESCRIPTION
In my setup i use browsersync to reload static resources and i would like to use livedev to reload go sources and resources. The setup looks like below:

browsersync (port 3000) -> livedev (port 7070) -> go app (port 8080)

The problem with this setup is that livedev creates a redirect loop, because it uses current port of the browser for the websocket connection. This fails because the current port is the one from browsersync.

This change will add the port to the live reload html snippet.
